### PR TITLE
Added input validator for desc field, checking for description length…

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -152,6 +152,21 @@ class Pod(TapisModel, table=True, validate=True):
             raise ValueError(f"Pod routing_port must be an int with 4 or 5 digits.")
         return v
 
+
+    @validator('description')
+    def check_description(cls, v):
+        # make sure only regular characters used 
+        r = list(string.ascii_lowercase + string.ascii_uppercase + string.hexdigits + '!.?@#')
+        spaceless_v = "".join(v.split())
+        for character in spaceless_v:
+            if character not in r:
+                raise ValueError(f"description field must only contain alphanumeric values or the following special characters: !.?@#")
+        # make sure description < 255 characters
+        if len(v) > 255:
+            raise ValueError(f"description field must be less than 255 characters.")
+        return v
+
+
     @root_validator(pre=False)
     def set_url_and_k8_name(cls, values):
         # NOTE: Pydantic loops during validation, so for a few calls, tenant_id and site_id will be NONE.

--- a/tests/tests_base.py
+++ b/tests/tests_base.py
@@ -83,6 +83,32 @@ def test_get_permissions(headers):
 
     assert result['permissions']
 
+def test_desc_length(headers):
+    rsp = client.post("/pods",
+                     data=json.dumps({"pod_id": test_pod_2,
+                                      "pod_template": "neo4j",
+                                      "description": "Test"*200}),
+                     headers=headers)
+
+    data = response_format(rsp)
+
+    # test for 400 error status code due to exceeding description length
+    assert rsp.status_code == 400
+
+    # test for right error message
+    assert 'description: description field must be less than 255 characters.' in data['message']
+
+def test_desc_char(headers):
+    rsp = client.post("/pods",
+                     data=json.dumps({"pod_id": test_pod_2,
+                                      "pod_template": "neo4j",
+                                      "description": "Test~~~"}),
+                     headers=headers)
+
+    data = response_format(rsp)
+    assert rsp.status_code == 400
+    assert 'description: description field must only contain alphanumeric values or the following special characters: !.?@#' in data['message']
+
 
 # Clean up
 def test_delete_pods(headers):


### PR DESCRIPTION
… < 255 characters and uses only alphanumeric and valid special characters (!.?@#) in `service/models.py`. 

Also wrote two unit tests in `tests/tests_base.py`:
- first one, making sure a description field input exceeding 255 characters gives a status code of `400` and displays correct error message.
- second one, making sure a description field input using a non-alphanumeric or special character not part of (!.?@#) gives a status code of `400` and displays correct error message.